### PR TITLE
Use import_module from standard library if exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,7 @@ matrix:
       env: DJANGO=1.3.7
     - python: "3.3"
       env: DJANGO=1.4.5
+    - python: "2.6"
+      env: DJANGO=1.7.4
+    - python: "2.6"
+      env: DJANGO=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
   - "3.2"
   - "3.3"
 before_install:
-  - export PIP_USE_MIRRORS=true
-  - export PIP_INDEX_URL=https://simple.crate.io/
   - export DJANGO_SETTINGS_MODULE=appconf.test_settings
 install:
   - pip install -e .
@@ -21,6 +19,7 @@ env:
   - DJANGO=1.3.7
   - DJANGO=1.4.5
   - DJANGO=1.5.1
+  - DJANGO=1.7.4
   - DJANGO=master
 
 matrix:

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Jannis Leidel
 Matthew Tretter
 Rafal Stozek
 Chris Streeter
+Patrick Altman

--- a/appconf/utils.py
+++ b/appconf/utils.py
@@ -2,7 +2,10 @@ import sys
 
 
 def import_attribute(import_path, exception_handler=None):
-    from django.utils.importlib import import_module
+    try:
+        from importlib import import_module
+    except ImportError:
+        from django.utils.importlib import import_module
     module_name, object_name = import_path.rsplit('.', 1)
     try:
         module = import_module(module_name)


### PR DESCRIPTION
Django 1.8+ drops `django.utils.importlib`. I imagine because that is because an older version of Python (either 2.5 and/or 2.6) is being dropped. I haven't checked older versions but `importlib` exists in Python 2.7.